### PR TITLE
Grant iam:GetRole to terraformer role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -5,7 +5,10 @@ resource "random_string" "profile-suffix" {
 
 data "aws_iam_policy_document" "permissions" {
   statement {
-    actions   = ["sts:AssumeRole"]
+    actions   = [
+      "sts:AssumeRole",
+      "iam:GetRole"
+    ]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
Why.
The secret module (https://registry.terraform.io/modules/infrahouse/secret/aws/latest) reads
```
data "aws_iam_role" "caller_role" {
```
It fails because this permissions is missing.
