### PR TITLE
Exclude terraformer instance from AWS Inspector

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ resource "aws_instance" "terraformer" {
   tags = merge(
     {
       Name : "terraformer"
+      InspectorEc2Exclusion : "true"
     },
     local.tags
   )


### PR DESCRIPTION
Terraformer instance is used for emergency operations on the Terraform
state. Potential vulnerabilities in ".terraform" directories are
accepted risk - when it comes to using terraformer, need to do it
regardless of present vulnerabilities.
